### PR TITLE
Add multicast support in ymmsl

### DIFF
--- a/docs/ymmsl_python.rst
+++ b/docs/ymmsl_python.rst
@@ -189,6 +189,38 @@ interpret these fields, e.g. to extract the component and port name parts.
 Note that the format allows specifying a slot here, but this is currently not
 supported and illegal in MUSCLE3.
 
+Multicast conduits
+^^^^^^^^^^^^^^^^^^
+
+In yMMSL you can specify that an output port is connected to multiple input
+ports. When a message is sent on the output port, it is copied and delivered to
+all connected input ports. This is called multicast and is expressed as
+follows:
+
+.. code-block:: yaml
+    :caption: Specifying multicast in yMMSL
+
+    conduits:
+      sender.port:
+      - receiver1.port
+      - receiver2.port
+
+This multicast conduit is converted to a a list of conduits sharing the same
+sender:
+
+.. code-block:: python
+    :caption: Multicast conduits in python code
+
+    from pathlib import Path
+    import ymmsl
+
+    config = ymmsl.load(Path('multicast.ymmsl'))
+
+    conduits = config.model.conduits
+    print(len(conduits))    # output: 2
+    print(conduits[0])      # output: Conduit(sender.port -> receiver1.port)
+    print(conduits[1])      # output: Conduit(sender.port -> receiver2.port)
+
 Settings
 --------
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,7 +4,7 @@ import pytest
 import yatiml
 
 from ymmsl import (Component, Conduit, Identifier, Model, ModelReference,
-                   Ports, Reference)
+                   Ports, Reference, load, dump)
 from ymmsl.model import MulticastConduit
 
 @pytest.fixture
@@ -215,6 +215,52 @@ def test_model_update_set_implementation() -> None:
     assert base.components[0].implementation == 'reaction_python'
 
 
+def test_model_multicast() -> None:
+    config_txt = """ymmsl_version: v0.1
+
+model:
+  name: multicast
+  components:
+    sender: sender
+    receiver: receiver
+    receiver1: receiver
+    receiver2: receiver
+  conduits:
+    sender.port: receiver.port
+    sender.multicast:
+    - receiver1.port
+    - receiver2.port"""
+
+    config = load(config_txt)
+    assert len(config.model.conduits) == 3
+    assert config.model.conduits[0].sender == "sender.port"
+    assert config.model.conduits[1].sender == "sender.multicast"
+    assert config.model.conduits[1].receiver == "receiver1.port"
+    assert config.model.conduits[2].sender == "sender.multicast"
+    assert config.model.conduits[2].receiver == "receiver2.port"
+
+    model_overlay = Model('multicast', [],
+            [Conduit("sender.port", "receiver2.port")])
+    config.model.update(model_overlay)
+    assert len(config.model.conduits) == 3
+
+    updated_config_txt = dump(config)
+    assert updated_config_txt == """ymmsl_version: v0.1
+model:
+  name: multicast
+  components:
+    sender: sender
+    receiver: receiver
+    receiver1: receiver
+    receiver2: receiver
+  conduits:
+    sender.port:
+    - receiver.port
+    - receiver2.port
+    sender.multicast: receiver1.port
+"""
+
+
 def test_model_check_consistent1(macro_micro: Model) -> None:
     macro_micro.check_consistent()
 
@@ -245,6 +291,13 @@ def test_model_check_consistent5(macro_micro: Model) -> None:
 
 def test_model_check_consistent6(macro_micro: Model) -> None:
     macro_micro.conduits[0].receiver = Reference('micro.final_state')
+    with pytest.raises(RuntimeError):
+        macro_micro.check_consistent()
+
+
+def test_model_check_consistent7(macro_micro: Model) -> None:
+    conduit = Conduit('macro.intermediate_state', 'micro.initial_state')
+    macro_micro.conduits.append(conduit)
     with pytest.raises(RuntimeError):
         macro_micro.check_consistent()
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -5,18 +5,20 @@ import yatiml
 
 from ymmsl import (Component, Conduit, Identifier, Model, ModelReference,
                    Ports, Reference)
-
+from ymmsl.model import MulticastConduit
 
 @pytest.fixture
 def load_model() -> Callable:
     return yatiml.load_function(
-            Model, Component, Conduit, Identifier, Ports, Reference)
+            Model, Component, Conduit, Identifier, Ports, Reference,
+            MulticastConduit)
 
 
 @pytest.fixture
 def dump_model() -> Callable:
     return yatiml.dumps_function(
-            Component, Conduit, Identifier, Model, Ports, Reference)
+            Component, Conduit, Identifier, Model, Ports, Reference,
+            MulticastConduit)
 
 
 @pytest.fixture
@@ -77,7 +79,7 @@ def test_conduit() -> None:
 def test_load_model_reference() -> None:
     load = yatiml.load_function(
             ModelReference, Component, Conduit, Identifier, Model,
-            ModelReference, Reference)
+            MulticastConduit, Reference)
 
     text = 'name: test_model\n'
     model = load(text)

--- a/ymmsl/io.py
+++ b/ymmsl/io.py
@@ -12,14 +12,14 @@ from ymmsl.execution import (
         MPINodesResReq, ThreadedResReq)
 from ymmsl.settings import Settings
 from ymmsl.identity import Identifier, Reference
-from ymmsl.model import Conduit, Model, ModelReference
+from ymmsl.model import Conduit, MulticastConduit, Model, ModelReference
 
 
 _classes = (
         PartialConfiguration, Component, Conduit, Configuration, Document,
         ExecutionModel, Identifier, Implementation, Model, ModelReference,
         MPICoresResReq, MPINodesResReq, Ports, Reference, ResourceRequirements,
-        Settings, ThreadedResReq)
+        Settings, ThreadedResReq, MulticastConduit)
 
 
 _load = yatiml.load_function(*_classes)

--- a/ymmsl/model.py
+++ b/ymmsl/model.py
@@ -161,7 +161,7 @@ class MulticastConduit:
                     References.
         """
         self.sender = sender
-        # note: atrribute must be called receiver to transparently work with
+        # note: attribute must be called receiver to transparently work with
         # seq_attribute_to_map and map_attribute_to_seq in
         # Model._yatiml_savorize and Model._yatiml_sweeten
         self.receiver = receiver
@@ -244,8 +244,8 @@ class Model(ModelReference):
         are overwritten if they have the same name as an existing
         argument or else added.
 
-        Conduits are added. If a receiving conduit was already connected, the
-        old conduit is removed. If a sending conduit was already connected, the
+        Conduits are added. If a receiving port was already connected, the
+        old conduit is removed. If a sending port was already connected, the
         new conduit is added and the sending port acts as a multicast port.
 
         Args:

--- a/ymmsl/model.py
+++ b/ymmsl/model.py
@@ -296,6 +296,7 @@ class Model(ModelReference):
                         pass
             return False
 
+        receivers_seen = set()
         for conduit in self.conduits:
             scomp = conduit.sending_component()
             if not component_exists(scomp):
@@ -322,6 +323,12 @@ class Model(ModelReference):
                         'Invalid conduit "{}": component "{}" does not'
                         ' have a receiving port "{}"'.format(
                             conduit, rcomp, rport))
+
+            if conduit.receiver in receivers_seen:
+                raise RuntimeError(
+                        'Receiving port "{}" is connected by multiple'
+                        ' conduits.'.format(conduit.receiver))
+            receivers_seen.add(conduit.receiver)
 
     def conduits_for_export(self) -> List[AnyConduit]:
         cond_dct = OrderedDict()  # type: OrderedDict[Reference, List[Conduit]]


### PR DESCRIPTION
Multicast means that one sending port is connected to multiple receiving ports. When a component sends a message on that port, it is copied and sent to each connected receiving port.

Tasks:
- [x] Support the syntax in ymmsl files
- [x] Support updating models and adding conduits on a sending port
- [x] Update documentation
- [x] Create pytest tests