### PR TITLE
Improve error when implementation not found an no similar impls present

### DIFF
--- a/ymmsl/v0_2/resolver.py
+++ b/ymmsl/v0_2/resolver.py
@@ -423,6 +423,9 @@ def find_impl(
             else:
                 msg += ' Did you mean any of these?\n'
                 msg += indent('- ' + '\n- '.join(matches), 8 * ' ')
+        else:
+            msg += ' Available implementations in this module:\n'
+            msg += indent('- ' + '\n- '.join(impls), 8 * ' ')
 
         raise RuntimeError(msg)
 


### PR DESCRIPTION
If there are no matches, then it's not just a typo, and then having more information is really useful.