### PR TITLE
Allow no resources for non-mpi simulations

### DIFF
--- a/docs/describing_runs.rst
+++ b/docs/describing_runs.rst
@@ -17,7 +17,8 @@ threads or processes can be specified; memory and GPUs are future work.
 Resources are specified per component, and apply to each instance of that component. For
 single- or multithreaded components, or components that use multiple local processes
 (for example with OpenMP, or Python's ``multiprocessing``), you specify the number of
-threads:
+threads. If no resource is defined for a non-MPI component, a default of 1 thread will
+be assigned to it at runtime (e.g. by MUSCLE3):
 
 .. code-block:: yaml
     :caption: Resources for threaded processes

--- a/docs/describing_runs.rst
+++ b/docs/describing_runs.rst
@@ -17,8 +17,7 @@ threads or processes can be specified; memory and GPUs are future work.
 Resources are specified per component, and apply to each instance of that component. For
 single- or multithreaded components, or components that use multiple local processes
 (for example with OpenMP, or Python's ``multiprocessing``), you specify the number of
-threads. If no resource is defined for a non-MPI component, a default of 1 thread will
-be assigned to it at runtime (e.g. by MUSCLE3):
+threads:
 
 .. code-block:: yaml
     :caption: Resources for threaded processes
@@ -30,6 +29,15 @@ be assigned to it at runtime (e.g. by MUSCLE3):
       micro:
         threads: 8
 
+If no resource is defined for a non-MPI component, a default of 1 thread will
+be assigned to it at runtime (e.g. by MUSCLE3). So, you could also define:
+
+.. code-block:: yaml
+    :caption: Resources for threaded processes
+
+    resources:
+      micro:
+        threads: 8
 
 On the Python side, this is represented by :class:`.ymmsl.v0_2.ThreadedResReq` (short
 for ThreadedResourceRequirements), which holds the name of the component it specifies

--- a/ymmsl/v0_1/execution.py
+++ b/ymmsl/v0_1/execution.py
@@ -326,6 +326,10 @@ class Implementation:
 class ResourceRequirements:
     """Describes resources to allocate for components.
 
+    For non-MPI components, specifying resources is optional. If no
+    resource is defined for a non-MPI component, a default of 1 thread
+    will be assigned to it at runtime (e.g. by MUSCLE3).
+
     Attributes:
         name: Name of the component to configure.
     """
@@ -349,6 +353,9 @@ class ThreadedResReq(ResourceRequirements):
     This includes singlethreaded and multithreaded implementations
     that do not support MPI. As many cores as specified will be
     allocated on a single node, for each instance.
+
+    If no resource is defined for a non-MPI component, a default of
+    1 thread will be assigned to it at runtime (e.g. by MUSCLE3).
 
     Attributes:
         name: Name of the component to configure.

--- a/ymmsl/v0_2/configuration.py
+++ b/ymmsl/v0_2/configuration.py
@@ -535,6 +535,9 @@ class Configuration(Document):
             self, component_paths: Dict[Reference, Component]) -> List[str]:
         """Check that each component path has a corresponding resource request.
 
+        For non-MPI components, resources are optional: if not specified,
+        a default of 1 thread will be assumed at runtime (e.g. by muscle3).
+
         Returns a list of errors, empty if all is ok.
         """
         errors = list()
@@ -543,16 +546,17 @@ class Configuration(Document):
             if impl_ref is None or impl_ref not in self.programs:
                 continue
 
+            impl = self.programs[impl_ref]
+            em_mpi = impl.execution_model in (
+                    ExecutionModel.OPENMPI, ExecutionModel.INTELMPI,
+                    ExecutionModel.SRUNMPI)
+
+            em_nompi = impl.execution_model is ExecutionModel.DIRECT
+
             if path not in self.resources:
-                errors.append(f'Component "{path}" is missing a resource request')
+                if em_mpi:
+                    errors.append(f'Component "{path}" is missing a resource request')
             else:
-                impl = self.programs[impl_ref]
-                em_mpi = impl.execution_model in (
-                        ExecutionModel.OPENMPI, ExecutionModel.INTELMPI,
-                        ExecutionModel.SRUNMPI)
-
-                em_nompi = impl.execution_model is ExecutionModel.DIRECT
-
                 res_mpi = isinstance(
                         self.resources[path], (MPICoresResReq, MPINodesResReq))
 

--- a/ymmsl/v0_2/configuration.py
+++ b/ymmsl/v0_2/configuration.py
@@ -11,7 +11,8 @@ import yaml
 
 from ymmsl.v0_2.checkpoint import Checkpoints
 from ymmsl.v0_2.execution import ExecutionModel
-from ymmsl.v0_2.resources import MPICoresResReq, MPINodesResReq, ResourceRequirements
+from ymmsl.v0_2.resources import (
+    MPICoresResReq, MPINodesResReq, ResourceRequirements, ThreadedResReq)
 from ymmsl.v0_2.identity import Identifier, Reference
 from ymmsl.v0_2.implementation import Implementation    # noqa: F401
 from ymmsl.v0_2.imports import ImportStatement
@@ -227,6 +228,26 @@ class Configuration(Document):
                     'The configuration is internally inconsistent. The following'
                     ' problems were found:\n- '
                     + '\n- '.join(errors))
+        
+    def get_resources(self, name: Reference) -> ResourceRequirements:
+        """Get the resource requirements for a component.
+
+        If no resources are defined for this component and
+        it uses a non-MPI execution model (DIRECT), a default of 1 thread is
+        returned.
+
+        Args:
+            name: The name of the component to get resources for.
+
+        Returns:
+            The resource requirements for the component.
+        """
+        res_req = self.resources.get(name)
+        if res_req is None:
+            _logger.debug(
+                    f'No resources defined for {name}, using default of 1 thread.')
+            res_req = ThreadedResReq(name, 1)
+        return res_req
 
     def root_model(self, selected_model: Optional[Reference] = None) -> Model:
         """Return the root model of this configuration.

--- a/ymmsl/v0_2/tests/test_configuration.py
+++ b/ymmsl/v0_2/tests/test_configuration.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from ymmsl.io import load, dump
+from ymmsl.io import load, load_as, dump
 from ymmsl.v0_2 import (
         Configuration, Checkpoints, Component, Conduit, ExecutionModel, Identifier,
         ImportStatement, Model, Operator, Port, Ports, Program, Reference, Settings,
@@ -456,7 +456,6 @@ def test_check_inconsistent_resources(
     with pytest.raises(RuntimeError) as e:
         config_inconsistent_resources.check_consistent()
 
-    # The missing resource for the non-MPI component is no longer an error.
     assert len(str(e.value).split('\n')) == 3
 
     config_inconsistent_resources.check_consistent(False)
@@ -464,13 +463,18 @@ def test_check_inconsistent_resources(
 
 def test_check_no_resources_for_non_mpi() -> None:
     """Non-MPI components without resources should pass check_consistent."""
-    model = Model(
-            'no_resources_test', None, 'description', None,
-            [Component('worker', Ports(), 'description', 'worker_prog')])
-
-    programs = [Program('worker_prog', script='worker', 
-                        execution_model=ExecutionModel.DIRECT)]
-
-    # No resources specified - should be fine for non-MPI
-    config = Configuration('test', None, [model], None, None, programs, resources=None)
+    ymmsl_text = """
+        ymmsl_version: v0.2
+        models:
+            no_resources_test:
+                components:
+                worker:
+                    ports: {}
+                    description: description
+                    implementation: worker_prog
+        programs:
+            worker_prog:
+                script: worker
+        """
+    config = load_as(Configuration, ymmsl_text)
     config.check_consistent()

--- a/ymmsl/v0_2/tests/test_configuration.py
+++ b/ymmsl/v0_2/tests/test_configuration.py
@@ -5,9 +5,9 @@ import pytest
 
 from ymmsl.io import load, dump
 from ymmsl.v0_2 import (
-        Configuration, Checkpoints, Component, Conduit, Identifier, ImportStatement,
-        Model, Operator, Port, Ports, Program, Reference, Settings, SettingType,
-        SettingValue, ThreadedResReq, Timeline)
+        Configuration, Checkpoints, Component, Conduit, ExecutionModel, Identifier,
+        ImportStatement, Model, Operator, Port, Ports, Program, Reference, Settings,
+        SettingType, SettingValue, ThreadedResReq, Timeline)
 
 
 Ref = Reference
@@ -456,6 +456,21 @@ def test_check_inconsistent_resources(
     with pytest.raises(RuntimeError) as e:
         config_inconsistent_resources.check_consistent()
 
-    assert len(str(e.value).split('\n')) == 4
+    # The missing resource for the non-MPI component is no longer an error.
+    assert len(str(e.value).split('\n')) == 3
 
     config_inconsistent_resources.check_consistent(False)
+
+
+def test_check_no_resources_for_non_mpi() -> None:
+    """Non-MPI components without resources should pass check_consistent."""
+    model = Model(
+            'no_resources_test', None, 'description', None,
+            [Component('worker', Ports(), 'description', 'worker_prog')])
+
+    programs = [Program('worker_prog', script='worker', 
+                        execution_model=ExecutionModel.DIRECT)]
+
+    # No resources specified - should be fine for non-MPI
+    config = Configuration('test', None, [model], None, None, programs, resources=None)
+    config.check_consistent()

--- a/ymmsl/v0_2/tests/test_configuration.py
+++ b/ymmsl/v0_2/tests/test_configuration.py
@@ -463,18 +463,18 @@ def test_check_inconsistent_resources(
 
 def test_check_no_resources_for_non_mpi() -> None:
     """Non-MPI components without resources should pass check_consistent."""
-    ymmsl_text = """
-        ymmsl_version: v0.2
-        models:
-            no_resources_test:
-                components:
-                worker:
-                    ports: {}
-                    description: description
-                    implementation: worker_prog
-        programs:
-            worker_prog:
-                script: worker
-        """
+    ymmsl_text = (
+            'ymmsl_version: v0.2\n'
+            'models:\n'
+            '  no_resources_test:\n'
+            '    components:\n'
+            '      worker:\n'
+            '        ports: {}\n'
+            '        description: description\n'
+            '        implementation: worker_prog\n'
+            'programs:\n'
+            '  worker_prog:\n'
+            '    script: worker\n'
+            )
     config = load_as(Configuration, ymmsl_text)
     config.check_consistent()

--- a/ymmsl/v0_2/tests/test_configuration.py
+++ b/ymmsl/v0_2/tests/test_configuration.py
@@ -5,7 +5,7 @@ import pytest
 
 from ymmsl.io import load, load_as, dump
 from ymmsl.v0_2 import (
-        Configuration, Checkpoints, Component, Conduit, ExecutionModel, Identifier,
+        Configuration, Checkpoints, Component, Conduit, Identifier,
         ImportStatement, Model, Operator, Port, Ports, Program, Reference, Settings,
         SettingType, SettingValue, ThreadedResReq, Timeline)
 

--- a/ymmsl/v0_2/tests/test_configuration.py
+++ b/ymmsl/v0_2/tests/test_configuration.py
@@ -461,6 +461,30 @@ def test_check_inconsistent_resources(
     config_inconsistent_resources.check_consistent(False)
 
 
+def test_get_resources_defined() -> None:
+    """Test that get_resources returns the defined resource for a component."""
+    resources = [
+            ThreadedResReq(Ref('macro'), 10),
+            ThreadedResReq(Ref('micro'), 1)]
+    config = Configuration('test', resources=resources)
+
+    res = config.get_resources(Ref('macro'))
+    assert isinstance(res, ThreadedResReq)
+    assert res.name == Ref('macro')
+    assert res.threads == 10
+
+
+def test_get_resources_default() -> None:
+    """Test that get_resources returns a default of 1 thread for a DIRECT component
+    with no resources defined."""
+    config = Configuration('test')
+
+    res = config.get_resources(Ref('micro'))
+    assert isinstance(res, ThreadedResReq)
+    assert res.name == Ref('micro')
+    assert res.threads == 1
+
+
 def test_check_no_resources_for_non_mpi() -> None:
     """Non-MPI components without resources should pass check_consistent."""
     ymmsl_text = (


### PR DESCRIPTION
If a non-MPI component is defined in the yMMSL file, you don't have to specify your resources. In muscle3 a default of 1 thread will be assigned if no resources are defined: [Muscle3 #PR 359](https://github.com/multiscale/muscle3/pull/359). 