### PR TITLE
Fix three bugs in one error message...

### DIFF
--- a/ymmsl/v0_2/configuration.py
+++ b/ymmsl/v0_2/configuration.py
@@ -492,11 +492,12 @@ class Configuration(Document):
                                 component, path, name, sup_set.typ, impl))
 
             if len(errs) > 7:
-                errs = errs[:6]
                 n = len(errs) - 6
+                errs = errs[:6]
                 errs.append(
-                        f'Another {n} inconsistent settings were found. Is "{impl}"'
-                        ' the correct implementation for component "{component.name}"?')
+                        f'Another {n} inconsistent settings were found. Is'
+                        f' "{impl.name}" the correct implementation for component'
+                        f' "{component.name}"?')
 
             errors.extend(errs)
 


### PR DESCRIPTION
- Count was always 0 because we update the length when truncating
- The implementation object was printed, rather than its name
- There was an f-string without the f, and that's perfectly fine syntactically but not what I meant

Addresses #49 