### PR TITLE
Import __version__ from package metadata to avoid mismatches

### DIFF
--- a/ymmsl/__init__.py
+++ b/ymmsl/__init__.py
@@ -3,6 +3,8 @@
 This package contains all the classes needed to represent a yMMSL file,
 as well as to read and write yMMSL files.
 """
+import importlib
+
 from ymmsl.conversion.converter import convert_to, DowngradeError
 from ymmsl.document import Document
 from ymmsl.io import dump, load, load_as, save
@@ -11,7 +13,7 @@ from ymmsl.io import dump, load, load_as, save
 from ymmsl.v0_2 import Operator, Settings
 
 
-__version__ = '0.15.1-dev'
+__version__ = importlib.metadata.version("ymmsl")
 __author__ = 'Lourens Veen'
 __email__ = 'l.veen@esciencecenter.nl'
 

--- a/ymmsl/__init__.py
+++ b/ymmsl/__init__.py
@@ -3,7 +3,7 @@
 This package contains all the classes needed to represent a yMMSL file,
 as well as to read and write yMMSL files.
 """
-import importlib
+from importlib.metadata import version as package_version
 
 from ymmsl.conversion.converter import convert_to, DowngradeError
 from ymmsl.document import Document
@@ -13,7 +13,7 @@ from ymmsl.io import dump, load, load_as, save
 from ymmsl.v0_2 import Operator, Settings
 
 
-__version__ = importlib.metadata.version("ymmsl")
+__version__ = package_version("ymmsl")
 __author__ = 'Lourens Veen'
 __email__ = 'l.veen@esciencecenter.nl'
 


### PR DESCRIPTION
I tried using setuptools-scm to get the version, but it turns out that that doesn't work with git-flow. Or at least, it'll work for releases, but for e.g. something on develop it will give an odd version because the latest release's tag is not an ancestor.

I think that that could be worked around with a custom setuptools-scm plugin, but that's a bit too complicated for now.

This keeps the version in pyproject.toml and requires manual changes, but at least the `ymmsl.__version__` now comes from the metadata and doesn't have to be synchronised by hand.

Addresses #48