### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Run the test suite
       run: |

--- a/.github/workflows/ci_python_compatibility.yaml
+++ b/.github/workflows/ci_python_compatibility.yaml
@@ -10,15 +10,15 @@ jobs:
 
     steps:
     - name: Check out the source code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache Tox
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ github.workspace }}/.tox
         key: python-compatibility-${{ matrix.python-version }}-tox


### PR DESCRIPTION
Updates the following actions to a newer version:
- actions/checkout: v4 -> v6
- actions/setup-python: v5 -> v6
- actions/cache: v4 -> v5

Change is required because the old versions used Node.js 20, which will be unsupported after September.