### PR TITLE
Ruff linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,5 +89,5 @@ select = [
   # flake8-simplify
   #"SIM",
   # isort
-  # "I",
+  "I",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ select = [
   # pyupgrade
   "UP",
   # flake8-bugbear
-  #"B",
+  "B",
   # isort
   "I",
   # TODO: enable these at some point?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,13 +81,18 @@ select = [
   "E",
   # Pyflakes
   "F",
-  # TODO: enable these at some point?
   # pyupgrade
-  # "UP",
+  "UP",
   # flake8-bugbear
   #"B",
-  # flake8-simplify
-  #"SIM",
   # isort
   "I",
+  # TODO: enable these at some point?
+  # flake8-simplify
+  #"SIM",
+]
+ignore = [
+  # yatiml requires Dict, List, etc.
+  "UP006",
+  "UP035",
 ]

--- a/ymmsl/__init__.py
+++ b/ymmsl/__init__.py
@@ -5,13 +5,12 @@ as well as to read and write yMMSL files.
 """
 from importlib.metadata import version as package_version
 
-from ymmsl.conversion.converter import convert_to, DowngradeError
+from ymmsl.conversion.converter import DowngradeError, convert_to
 from ymmsl.document import Document
 from ymmsl.io import dump, load, load_as, save
 
 # For backwards compatibility of programs
 from ymmsl.v0_2 import Operator, Settings
-
 
 __version__ = package_version("ymmsl")
 __author__ = 'Lourens Veen'

--- a/ymmsl/command_line.py
+++ b/ymmsl/command_line.py
@@ -1,14 +1,15 @@
-import click
 import os
+import warnings
 from shutil import copyfile
 from typing import Dict, Optional, TextIO, Type, Union
-import warnings
 
+import click
+
+import ymmsl.v0_1 as v0_1
+import ymmsl.v0_2 as v0_2
 from ymmsl.conversion.converter import DowngradeError
 from ymmsl.document import Document
 from ymmsl.io import load_as, save
-import ymmsl.v0_1 as v0_1
-import ymmsl.v0_2 as v0_2
 
 
 def showwarning(

--- a/ymmsl/conversion/convert_v0_1_to_v0_2.py
+++ b/ymmsl/conversion/convert_v0_1_to_v0_2.py
@@ -24,19 +24,22 @@ def convert_v0_1_to_v0_2(config: v0_1.PartialConfiguration) -> v0_2.Configuratio
             convert_implementation(impl) for impl in config.implementations.values()]
     if programs:
         warnings.warn(
-                'In yMMSL v0.2 implementations have become programs, and you can now'
-                ' specify the ports of a program in the yMMSL description. If your'
-                ' program has fixed ports then you should do this, because it will make'
-                ' incorrect wiring easier to debug. While there, add a description too!'
-                )
+            'In yMMSL v0.2 implementations have become programs, and you can now'
+            ' specify the ports of a program in the yMMSL description. If your'
+            ' program has fixed ports then you should do this, because it will make'
+            ' incorrect wiring easier to debug. While there, add a description too!',
+            stacklevel=2,
+        )
 
     resources = convert_resources(config.resources, models)
     checkpoints = deepcopy(config.checkpoints)
     resume = deepcopy(config.resume)
 
     warnings.warn(
-            'Comments can unfortunately not be read by this converter, and so have been'
-            ' ignored. Please copy them into an appropriate description field.')
+        'Comments can unfortunately not be read by this converter, and so have been'
+        ' ignored. Please copy them into an appropriate description field.',
+        stacklevel=2,
+    )
 
     return v0_2.Configuration(
             description, None, models, None, settings, programs, resources, checkpoints,
@@ -94,7 +97,7 @@ def infer_ports(components: List[v0_2.Component], conduits: List[v0_2.Conduit]) 
                 ' been added based on the connected conduits. THIS MAY BE WRONG,'
                 ' because the operators have all been set to F_INIT and O_F, while they'
                 ' may really be O_I or S. Please check these components and adjust'
-                f' as needed: {ch_comp_list}')
+                f' as needed: {ch_comp_list}', stacklevel=4)
 
 
 def convert_model(model: v0_1.ModelReference) -> v0_2.Model:
@@ -174,7 +177,7 @@ def convert_resources(
                 ' prefixed with the name of the top (outermost) model, e.g. as'
                 ' my_model.my_component rather than just my_component. This file'
                 ' does not contain a model, so its name cannot be added automatically.'
-                ' Please add the model name yourself.')
+                ' Please add the model name yourself.', stacklevel=3)
         return deepcopy(resources)
     else:
         mname = models[0].name

--- a/ymmsl/conversion/convert_v0_1_to_v0_2.py
+++ b/ymmsl/conversion/convert_v0_1_to_v0_2.py
@@ -1,6 +1,6 @@
+import warnings
 from copy import deepcopy
 from typing import Dict, List, MutableMapping, Optional
-import warnings
 
 import ymmsl.v0_1 as v0_1
 import ymmsl.v0_2 as v0_2

--- a/ymmsl/conversion/converter.py
+++ b/ymmsl/conversion/converter.py
@@ -1,9 +1,9 @@
-from typing import Callable, cast, Dict, Type, TypeVar
+from typing import Callable, Dict, Type, TypeVar, cast
 
-from ymmsl.conversion.convert_v0_1_to_v0_2 import convert_v0_1_to_v0_2
-from ymmsl.document import Document
 import ymmsl.v0_1 as v0_1
 import ymmsl.v0_2 as v0_2
+from ymmsl.conversion.convert_v0_1_to_v0_2 import convert_v0_1_to_v0_2
+from ymmsl.document import Document
 
 
 class DowngradeError(RuntimeError):

--- a/ymmsl/conversion/tests/test_convert_v0_1_to_v0_2.py
+++ b/ymmsl/conversion/tests/test_convert_v0_1_to_v0_2.py
@@ -2,11 +2,9 @@ from pathlib import Path
 
 import pytest
 
-from ymmsl.conversion.convert_v0_1_to_v0_2 import convert_v0_1_to_v0_2
-
 import ymmsl.v0_1 as v0_1
 import ymmsl.v0_2 as v0_2
-
+from ymmsl.conversion.convert_v0_1_to_v0_2 import convert_v0_1_to_v0_2
 
 Ref1 = v0_1.Reference
 

--- a/ymmsl/conversion/tests/test_converter.py
+++ b/ymmsl/conversion/tests/test_converter.py
@@ -1,9 +1,8 @@
 import pytest
 
-from ymmsl.conversion.converter import convert_to
-
 import ymmsl.v0_1 as v0_1
 import ymmsl.v0_2 as v0_2
+from ymmsl.conversion.converter import convert_to
 
 
 def test_convert_to_no_change(full_config: v0_1.PartialConfiguration) -> None:

--- a/ymmsl/document.py
+++ b/ymmsl/document.py
@@ -1,7 +1,6 @@
-from abc import ABC
 
-
-class Document(ABC):
+class Document:
     """Base class for ymmsl documents of all versions"""
+
     def __init__(self) -> None:
         pass

--- a/ymmsl/io.py
+++ b/ymmsl/io.py
@@ -1,19 +1,16 @@
 """Loading and saving functions."""
 from pathlib import Path
-from typing import Any, IO, Type, TypeVar, Union
+from typing import IO, Any, Type, TypeVar, Union
 
 import yatiml
 
+import ymmsl.v0_1 as v0_1
+import ymmsl.v0_2 as v0_2
 from ymmsl.conversion.converter import convert_to
 from ymmsl.document import Document
-
-import ymmsl.v0_1 as v0_1
 from ymmsl.v0_1.document import Document as v0_1_Document
 from ymmsl.v0_1.model import MulticastConduit as v0_1_MulticastConduit
-
-import ymmsl.v0_2 as v0_2
 from ymmsl.v0_2.model import MulticastConduit as v0_2_MulticastConduit
-
 
 _classes = (
         Document,

--- a/ymmsl/tests/conftest.py
+++ b/ymmsl/tests/conftest.py
@@ -4,12 +4,26 @@ from pathlib import Path
 import pytest
 
 from ymmsl.v0_1 import (
-        BaseEnv, Component, Conduit, Configuration, ExecutionModel, Implementation,
-        CheckpointRangeRule, CheckpointAtRule, Checkpoints, KeepsStateForNextUse,
-        Model, MPICoresResReq, MPINodesResReq,
-        PartialConfiguration, Ports, Reference, Settings, ThreadedResReq)
+    BaseEnv,
+    CheckpointAtRule,
+    CheckpointRangeRule,
+    Checkpoints,
+    Component,
+    Conduit,
+    Configuration,
+    ExecutionModel,
+    Implementation,
+    KeepsStateForNextUse,
+    Model,
+    MPICoresResReq,
+    MPINodesResReq,
+    PartialConfiguration,
+    Ports,
+    Reference,
+    Settings,
+    ThreadedResReq,
+)
 from ymmsl.v0_1.model import ModelReference
-
 
 Ref = Reference
 

--- a/ymmsl/tests/test_examples.py
+++ b/ymmsl/tests/test_examples.py
@@ -1,7 +1,7 @@
+from pathlib import Path
+
 from ymmsl import load_as
 from ymmsl.v0_2 import Configuration
-
-from pathlib import Path
 
 
 def test_load_examples() -> None:

--- a/ymmsl/tests/test_io.py
+++ b/ymmsl/tests/test_io.py
@@ -1,8 +1,8 @@
-import ymmsl
-from ymmsl import v0_2
+import pytest
 import yatiml
 
-import pytest
+import ymmsl
+from ymmsl import v0_2
 
 
 def test_invalid_version() -> None:

--- a/ymmsl/tests/test_io_v0_1.py
+++ b/ymmsl/tests/test_io_v0_1.py
@@ -2,14 +2,22 @@ from pathlib import Path
 from typing import Any, cast
 
 import pytest
-
 from yatiml import RecognitionError
+
 from ymmsl.io import dump, load, save
 from ymmsl.v0_1 import (
-        Configuration, ExecutionModel, KeepsStateForNextUse, Model, ModelReference,
-        MPICoresResReq, MPINodesResReq, PartialConfiguration, Reference,
-        ThreadedResReq, CheckpointRangeRule)
-
+    CheckpointRangeRule,
+    Configuration,
+    ExecutionModel,
+    KeepsStateForNextUse,
+    Model,
+    ModelReference,
+    MPICoresResReq,
+    MPINodesResReq,
+    PartialConfiguration,
+    Reference,
+    ThreadedResReq,
+)
 
 Ref = Reference
 

--- a/ymmsl/tests/test_load_as.py
+++ b/ymmsl/tests/test_load_as.py
@@ -1,10 +1,10 @@
-from typing import cast, List
-
-from ymmsl.io import load_as
-import ymmsl.v0_1 as v0_1
-import ymmsl.v0_2 as v0_2
+from typing import List, cast
 
 import pytest
+
+import ymmsl.v0_1 as v0_1
+import ymmsl.v0_2 as v0_2
+from ymmsl.io import load_as
 
 
 def test_load_as_v0_1(test_yaml1: str) -> None:

--- a/ymmsl/v0_1/__init__.py
+++ b/ymmsl/v0_1/__init__.py
@@ -5,17 +5,26 @@ as well as to read and write yMMSL files.
 """
 
 from ymmsl.v0_1.checkpoint import (
-        CheckpointRule, CheckpointRangeRule, CheckpointAtRule, Checkpoints)
+        CheckpointAtRule,
+        CheckpointRangeRule,
+        CheckpointRule,
+        Checkpoints,
+)
 from ymmsl.v0_1.component import Component, Operator, Port, Ports
 from ymmsl.v0_1.configuration import Configuration, PartialConfiguration
 from ymmsl.v0_1.execution import (
-        BaseEnv, ExecutionModel, Implementation, MPICoresResReq,
-        MPINodesResReq, ResourceRequirements, ThreadedResReq,
-        KeepsStateForNextUse)
-from ymmsl.v0_1.settings import Settings, SettingValue
+        BaseEnv,
+        ExecutionModel,
+        Implementation,
+        KeepsStateForNextUse,
+        MPICoresResReq,
+        MPINodesResReq,
+        ResourceRequirements,
+        ThreadedResReq,
+)
 from ymmsl.v0_1.identity import Identifier, Reference
 from ymmsl.v0_1.model import Conduit, Model, ModelReference
-
+from ymmsl.v0_1.settings import Settings, SettingValue
 
 __all__ = [
         'BaseEnv', 'CheckpointRule', 'CheckpointRangeRule', 'CheckpointAtRule',

--- a/ymmsl/v0_1/component.py
+++ b/ymmsl/v0_1/component.py
@@ -1,15 +1,19 @@
 """Definitions for describing simulation components."""
+import logging
 from collections import OrderedDict
 from enum import Enum
-import logging
-from typing import Dict     # noqa: F401
-from typing import Iterable, List, Optional, Union
+from typing import (
+    Dict,  # noqa: F401
+    Iterable,
+    List,
+    Optional,
+    Union,
+)
 
 import yaml
 import yatiml
 
 from ymmsl.v0_1.identity import Identifier, Reference
-
 
 _logger = logging.getLogger(__name__)
 

--- a/ymmsl/v0_1/component.py
+++ b/ymmsl/v0_1/component.py
@@ -157,7 +157,7 @@ class Ports:
         if port_name in self.o_f:
             return Operator.O_F
 
-        raise KeyError('No port named "{}" was found'.format(port_name))
+        raise KeyError(f'No port named "{port_name}" was found')
 
     _yatiml_defaults: dict[str, Optional[list[str]]] = {
             'f_init': [],
@@ -213,9 +213,8 @@ class Component:
             self.implementation = Reference(implementation)
             for part in self.implementation:
                 if isinstance(part, int):
-                    raise ValueError('Component implementation {} contains a'
-                                     ' subscript, which is not'
-                                     ' allowed.'.format(self.name))
+                    raise ValueError(f"Component implementation {self.name} contains a"
+                                     " subscript, which is not allowed.")
 
         if multiplicity is None:
             self.multiplicity = list()
@@ -230,12 +229,12 @@ class Component:
         """Returns a string representation of the object."""
         result = str(self.name)
         for dim in self.multiplicity:
-            result += '[0:{}]'.format(dim)
+            result += f"[0:{dim}]"
         return result
 
     def __repr__(self) -> str:
         """Returns a string representation of the object."""
-        return 'Component({})'.format(self.name)
+        return f"Component({self.name})"
 
     def instances(self) -> List[Reference]:
         """Creates a list of instances needed.

--- a/ymmsl/v0_1/configuration.py
+++ b/ymmsl/v0_1/configuration.py
@@ -1,23 +1,24 @@
 """This module contains all the definitions for yMMSL."""
-from collections import OrderedDict
 import collections.abc as abc
 import logging
+from collections import OrderedDict
 from pathlib import Path
-from typing import (
-        Dict, List, MutableMapping, Optional, Sequence, Union, cast)
+from typing import Dict, List, MutableMapping, Optional, Sequence, Union, cast
 
-import yatiml
 import yaml
+import yatiml
 
 from ymmsl.v0_1.checkpoint import Checkpoints
 from ymmsl.v0_1.document import Document
-from ymmsl.v0_1.identity import Reference
 from ymmsl.v0_1.execution import (
-        ExecutionModel, Implementation,
-        ResourceRequirements, ThreadedResReq)
-from ymmsl.v0_1.settings import Settings
+    ExecutionModel,
+    Implementation,
+    ResourceRequirements,
+    ThreadedResReq,
+)
+from ymmsl.v0_1.identity import Reference
 from ymmsl.v0_1.model import Model, ModelReference
-
+from ymmsl.v0_1.settings import Settings
 
 _logger = logging.getLogger(__name__)
 

--- a/ymmsl/v0_1/configuration.py
+++ b/ymmsl/v0_1/configuration.py
@@ -312,13 +312,13 @@ class Configuration(PartialConfiguration):
 
         for comp in self.model.components:
             if comp.implementation not in self.implementations:
-                raise RuntimeError((
-                        'Model component {} is missing an'
-                        ' implementation').format(comp))
+                raise RuntimeError(
+                    f"Model component {comp} is missing an implementation."
+                )
             if comp.name not in self.resources:
-                raise RuntimeError((
-                        'Model component {} is missing a resource'
-                        ' allocation.').format(comp))
+                raise RuntimeError(
+                    f"Model component {comp} is missing a resource allocation."
+                )
 
             impl = self.implementations[comp.implementation]
             res = self.resources[comp.name]
@@ -326,19 +326,19 @@ class Configuration(PartialConfiguration):
                 if not isinstance(res, ThreadedResReq) and impl.script is None:
                     # Assume that people know what they're doing if they use
                     # script for specifying an implementation.
-                    raise RuntimeError((
-                        'Model component {}\'s implementation does not'
+                    raise RuntimeError(
+                        f"Model component {comp}'s implementation specifies MPI,"
                         ' specify MPI, but mpi_processes are specified in its'
                         ' resources. Please either set "execution_model" to'
                         ' an MPI model, or specify a number of threads.'
-                        ).format(comp))
+                    )
             else:
                 if isinstance(res, ThreadedResReq):
-                    raise RuntimeError((
-                        'Model component {}\'s implementation specifies MPI,'
+                    raise RuntimeError(
+                        f"Model component {comp}'s implementation specifies MPI,"
                         ' but threads are specified in its resources. Please'
                         ' either set "execution_model" to "direct", or'
-                        ' specify a number of mpi processes.').format(comp))
+                        ' specify a number of mpi processes.')
 
     @classmethod
     def _yatiml_recognize(cls, node: yatiml.UnknownNode) -> None:

--- a/ymmsl/v0_1/configuration.py
+++ b/ymmsl/v0_1/configuration.py
@@ -264,12 +264,12 @@ class Configuration(PartialConfiguration):
     def __init__(self,
                  model: Model,
                  settings: Optional[Settings] = None,
-                 implementations: Union[
+                 implementations: Optional[Union[
                      List[Implementation],
-                     Dict[Reference, Implementation]] = [],
-                 resources: Union[
+                     Dict[Reference, Implementation]]] = None,
+                 resources: Optional[Union[
                      Sequence[ResourceRequirements],
-                     MutableMapping[Reference, ResourceRequirements]] = [],
+                     MutableMapping[Reference, ResourceRequirements]]] = None,
                  description: Optional[str] = None,
                  checkpoints: Optional[Checkpoints] = None,
                  resume: Optional[Dict[Reference, Path]] = None

--- a/ymmsl/v0_1/document.py
+++ b/ymmsl/v0_1/document.py
@@ -1,5 +1,6 @@
 """Defines the YAML document and version tag."""
 import yatiml
+
 from ymmsl.document import Document as DocumentBase
 
 

--- a/ymmsl/v0_1/execution.py
+++ b/ymmsl/v0_1/execution.py
@@ -1,7 +1,7 @@
 """Definitions for specifying how to start a component."""
 from enum import Enum
 from pathlib import Path
-from typing import cast, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, cast
 
 import yaml
 import yatiml

--- a/ymmsl/v0_1/identity.py
+++ b/ymmsl/v0_1/identity.py
@@ -1,8 +1,8 @@
 """This module contains definitions for identity."""
-from copy import copy
 import re
 from collections import UserString
-from typing import Any, Generator, Iterable, List, overload, Union
+from copy import copy
+from typing import Any, Generator, Iterable, List, Union, overload
 
 import yatiml
 

--- a/ymmsl/v0_1/identity.py
+++ b/ymmsl/v0_1/identity.py
@@ -31,7 +31,7 @@ class Identifier(UserString):
                              ' lower- and uppercase letters, digits and'
                              ' underscores, must start with a letter or'
                              ' an underscore, and must not be empty.'
-                             ' "{}" is therefore invalid.'.format(self.data))
+                             f' "{self.data}" is therefore invalid.')
 
 
 ReferencePart = Union[Identifier, int]
@@ -93,7 +93,7 @@ class Reference(yatiml.String):
 
     def __repr__(self) -> str:
         """Produce a representation in string form."""
-        return 'Reference("{}")'.format(str(self))
+        return f'Reference("{self}")'
 
     def __len__(self) -> int:
         """Return the number of parts in the Reference."""
@@ -176,8 +176,7 @@ class Reference(yatiml.String):
             Each part in turn from left to right.
 
         """
-        for part in self._parts:
-            yield part
+        yield from self._parts
 
     @overload
     def __getitem__(self, key: int) -> ReferencePart: ...
@@ -295,20 +294,19 @@ class Reference(yatiml.String):
             elif text[cur_op] == '[':
                 close_bracket = text.find(']', cur_op)
                 if close_bracket == -1:
-                    raise ValueError('Missing closing bracket in Reference {}'
-                                     ''.format(text))
+                    raise ValueError(f"Missing closing bracket in Reference {text}")
                 try:
                     index = int(text[cur_op + 1:close_bracket])
                 except ValueError as exc:
-                    raise ValueError('Invalid index \'{}\' in {}, expected an'
-                                     ' int'.format(
-                                         text[cur_op + 1:close_bracket], text)
-                                     ) from exc
+                    raise ValueError(
+                        f"Invalid index '{text[cur_op + 1 : close_bracket]}' in "
+                        f"{text}, expected an int"
+                    ) from exc
                 parts.append(index)
                 cur_op = close_bracket + 1
             else:
-                raise ValueError('Invalid character \'{}\' encountered in'
-                                 ' Reference {}'.format(text[cur_op], text))
+                raise ValueError(f"Invalid character '{text[cur_op]}' encountered in"
+                                 f" Reference {text}")
         return parts
 
     @classmethod
@@ -328,7 +326,7 @@ class Reference(yatiml.String):
         text = str(parts[0])
         for part in parts[1:]:
             if isinstance(part, int):
-                text += '[{}]'.format(part)
+                text += f"[{part}]"
             else:
-                text += '.{}'.format(part)
+                text += f".{part}"
         return text

--- a/ymmsl/v0_1/model.py
+++ b/ymmsl/v0_1/model.py
@@ -1,12 +1,21 @@
 """This module contains all the definitions for yMMSL."""
 from collections import OrderedDict
-from typing import Any, List, Optional, Sequence, Union, cast
-from typing import Dict     # noqa
+from typing import (
+    Any,
+    Dict,  # noqa
+    List,
+    Optional,
+    Sequence,
+    Union,
+    cast,
+)
 
 import yatiml
 
-from ymmsl.v0_1.component import Operator    # noqa
-from ymmsl.v0_1.component import Component
+from ymmsl.v0_1.component import (
+    Component,
+    Operator,  # noqa
+)
 from ymmsl.v0_1.identity import Identifier, Reference
 
 

--- a/ymmsl/v0_1/model.py
+++ b/ymmsl/v0_1/model.py
@@ -52,7 +52,7 @@ class Conduit:
 
     def __str__(self) -> str:
         """Return a string representation of the object."""
-        return 'Conduit({} -> {})'.format(self.sender, self.receiver)
+        return f"Conduit({self.sender} -> {self.receiver})"
 
     def __eq__(self, other: Any) -> bool:
         """Returns whether the conduits connect the same ports."""
@@ -67,19 +67,19 @@ class Conduit:
         for i, part in enumerate(ref):
             if isinstance(part, int):
                 if (i+1) < len(ref) and isinstance(ref[i+1], Identifier):
-                    raise ValueError('Reference {} contains a subscript that'
-                                     ' is not at the end, which is not allowed'
-                                     ' in conduits.'.format(ref))
+                    raise ValueError(f"Reference {ref} contains a subscript that"
+                                     " is not at the end, which is not allowed"
+                                     " in conduits.")
 
         # check that the length is at least 2
         if len(Conduit.__stem(ref)) < 2:
-            raise ValueError((
-                    'Senders and receivers in conduits must have a component'
-                    ' name, a period, and then a port name and optionally a'
-                    ' slot. Reference {} is missing either the component or'
-                    ' the port. Did you perhaps type a comma or an underscore'
+            raise ValueError(
+                    "Senders and receivers in conduits must have a component"
+                    " name, a period, and then a port name and optionally a"
+                    f" slot. Reference {ref} is missing either the component or"
+                    " the port. Did you perhaps type a comma or an underscore"
                     ' instead of a period? It should be "component.port"'
-                    ).format(ref))
+                    )
 
     def sending_component(self) -> Reference:
         """Returns a reference to the sending component."""
@@ -331,33 +331,29 @@ class Model(ModelReference):
             scomp = conduit.sending_component()
             if not component_exists(scomp):
                 raise RuntimeError(
-                    'Unknown sending component "{}" of {}'.format(
-                        scomp, conduit))
+                    f'Unknown sending component "{scomp}" of {conduit}')
 
             rcomp = conduit.receiving_component()
             if not component_exists(rcomp):
                 raise RuntimeError(
-                    'Unknown receiving component "{}" of {}'.format(
-                        rcomp, conduit))
+                    f'Unknown receiving component "{rcomp}" of {conduit}')
 
             sport = conduit.sending_port()
             if not component_has_sending_port(scomp, sport):
                 raise RuntimeError(
-                        'Invalid conduit "{}": component "{}" does not'
-                        ' have a sending port "{}"'.format(
-                            conduit, scomp, sport))
+                        f'Invalid conduit "{conduit}": component "{scomp}" does not'
+                        f' have a sending port "{sport}"')
 
             rport = conduit.receiving_port()
             if not component_has_receiving_port(rcomp, rport):
                 raise RuntimeError(
-                        'Invalid conduit "{}": component "{}" does not'
-                        ' have a receiving port "{}"'.format(
-                            conduit, rcomp, rport))
+                        f'Invalid conduit "{conduit}": component "{rcomp}" does not'
+                        f' have a receiving port "{rport}"')
 
             if conduit.receiver in receivers_seen:
                 raise RuntimeError(
-                        'Receiving port "{}" is connected by multiple'
-                        ' conduits.'.format(conduit.receiver))
+                        f'Receiving port "{conduit.receiver}" is connected by multiple'
+                        " conduits.")
             receivers_seen.add(conduit.receiver)
 
     def __conduits_for_export(self) -> List[AnyConduit]:

--- a/ymmsl/v0_1/settings.py
+++ b/ymmsl/v0_1/settings.py
@@ -2,12 +2,11 @@
 from collections import OrderedDict
 from collections.abc import MutableMapping
 from copy import deepcopy
-from typing import Any, Dict, Iterator, List, Optional, overload, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, TypeVar, Union, overload
 
 import yatiml
 
 from ymmsl.v0_1.identity import Reference
-
 
 SettingValue = Union[
         str, int, float, bool, List[int], List[float], List[List[float]],

--- a/ymmsl/v0_1/tests/conftest.py
+++ b/ymmsl/v0_1/tests/conftest.py
@@ -3,11 +3,22 @@ from pathlib import Path
 import pytest
 
 from ymmsl.v0_1 import (
-        BaseEnv, Component, Conduit, Configuration, ExecutionModel, Implementation,
-        CheckpointRangeRule, CheckpointAtRule, Checkpoints,
-        Model, MPICoresResReq, MPINodesResReq,
-        PartialConfiguration, Reference, ThreadedResReq)
-
+    BaseEnv,
+    CheckpointAtRule,
+    CheckpointRangeRule,
+    Checkpoints,
+    Component,
+    Conduit,
+    Configuration,
+    ExecutionModel,
+    Implementation,
+    Model,
+    MPICoresResReq,
+    MPINodesResReq,
+    PartialConfiguration,
+    Reference,
+    ThreadedResReq,
+)
 
 Ref = Reference
 

--- a/ymmsl/v0_1/tests/test_checkpoint.py
+++ b/ymmsl/v0_1/tests/test_checkpoint.py
@@ -4,7 +4,11 @@ import pytest
 import yatiml
 
 from ymmsl.v0_1.checkpoint import (
-        CheckpointRangeRule, CheckpointAtRule, CheckpointRule, Checkpoints)
+    CheckpointAtRule,
+    CheckpointRangeRule,
+    CheckpointRule,
+    Checkpoints,
+)
 
 
 def test_checkpointrange() -> None:

--- a/ymmsl/v0_1/tests/test_configuration.py
+++ b/ymmsl/v0_1/tests/test_configuration.py
@@ -2,13 +2,23 @@ from collections import OrderedDict
 from pathlib import Path
 
 import pytest
-from ymmsl.io import load, dump
-from ymmsl.v0_1 import (
-        Component, Configuration, ExecutionModel, Implementation, Model, MPICoresResReq,
-        Checkpoints, PartialConfiguration, Reference, Settings, ThreadedResReq)
-from ymmsl.v0_1 import SettingValue     # noqa: F401 # pylint: disable=unused-import
-from ymmsl.v0_1.model import ModelReference
 
+from ymmsl.io import dump, load
+from ymmsl.v0_1 import (
+    Checkpoints,
+    Component,
+    Configuration,
+    ExecutionModel,
+    Implementation,
+    Model,
+    MPICoresResReq,
+    PartialConfiguration,
+    Reference,
+    Settings,
+    SettingValue,  # noqa: F401 # pylint: disable=unused-import
+    ThreadedResReq,
+)
+from ymmsl.v0_1.model import ModelReference
 
 Ref = Reference
 

--- a/ymmsl/v0_1/tests/test_execution.py
+++ b/ymmsl/v0_1/tests/test_execution.py
@@ -1,8 +1,14 @@
 from pathlib import Path
 
 import pytest
+
 from ymmsl.v0_1 import (
-        BaseEnv, ExecutionModel, Implementation, KeepsStateForNextUse, Reference)
+    BaseEnv,
+    ExecutionModel,
+    Implementation,
+    KeepsStateForNextUse,
+    Reference,
+)
 
 
 def test_implementation() -> None:

--- a/ymmsl/v0_1/tests/test_identity.py
+++ b/ymmsl/v0_1/tests/test_identity.py
@@ -1,7 +1,7 @@
-from ymmsl.v0_1 import Identifier, Reference
-
 import pytest
 import yatiml
+
+from ymmsl.v0_1 import Identifier, Reference
 
 
 def test_create_identifier() -> None:

--- a/ymmsl/v0_1/tests/test_model.py
+++ b/ymmsl/v0_1/tests/test_model.py
@@ -3,10 +3,17 @@ from typing import Callable
 import pytest
 import yatiml
 
-from ymmsl.io import load, dump
+from ymmsl.io import dump, load
 from ymmsl.v0_1 import (
-        Component, Conduit, Identifier, Model, ModelReference,
-        PartialConfiguration, Ports, Reference)
+    Component,
+    Conduit,
+    Identifier,
+    Model,
+    ModelReference,
+    PartialConfiguration,
+    Ports,
+    Reference,
+)
 from ymmsl.v0_1.model import MulticastConduit
 
 

--- a/ymmsl/v0_1/tests/test_settings.py
+++ b/ymmsl/v0_1/tests/test_settings.py
@@ -129,8 +129,7 @@ def test_del_item(settings: Settings) -> None:
 
 def test_iter(settings: Settings) -> None:
     assert len(settings) == 0
-    for setting, value in settings.items():
-        assert False    # pragma: no cover
+    assert list(settings.items()) == []
 
     settings._store = OrderedDict([
             (Reference('test1'), 13),

--- a/ymmsl/v0_1/tests/test_settings.py
+++ b/ymmsl/v0_1/tests/test_settings.py
@@ -1,11 +1,15 @@
-from ymmsl.v0_1 import Identifier, Reference, Settings
-from ymmsl.v0_1 import SettingValue  # noqa: F401 # pytest: disable=W0611
-
 from collections import OrderedDict
-from typing import cast, List
-import yatiml
+from typing import List, cast
 
 import pytest
+import yatiml
+
+from ymmsl.v0_1 import (
+    Identifier,
+    Reference,
+    Settings,
+    SettingValue,  # noqa: F401 # pytest: disable=W0611
+)
 
 
 @pytest.fixture

--- a/ymmsl/v0_1/tests/test_settings.py
+++ b/ymmsl/v0_1/tests/test_settings.py
@@ -207,7 +207,7 @@ def test_as_ordered_dict(settings: Settings) -> None:
     assert settings_dict['test4'] == [12.3, 45.6]
 
     for i, (key, _) in enumerate(settings_dict.items()):
-        assert key == 'test{}'.format(i + 1)
+        assert key == f"test{i + 1}"
 
 
 def test_load_settings() -> None:

--- a/ymmsl/v0_2/__init__.py
+++ b/ymmsl/v0_2/__init__.py
@@ -1,5 +1,9 @@
 from ymmsl.v0_2.checkpoint import (
-        CheckpointRule, CheckpointRangeRule, CheckpointAtRule, Checkpoints)
+        CheckpointAtRule,
+        CheckpointRangeRule,
+        CheckpointRule,
+        Checkpoints,
+)
 from ymmsl.v0_2.component import Component
 from ymmsl.v0_2.configuration import Configuration
 from ymmsl.v0_2.document import Document
@@ -10,13 +14,19 @@ from ymmsl.v0_2.imports import ImportKind, ImportStatement
 from ymmsl.v0_2.model import Conduit, ConduitFilter, Model
 from ymmsl.v0_2.ports import Operator, Port, Ports, Timeline
 from ymmsl.v0_2.program import Program
-from ymmsl.v0_2.resources import (
-        MPICoresResReq, MPINodesResReq, ResourceRequirements, ThreadedResReq)
 from ymmsl.v0_2.resolver import resolve
+from ymmsl.v0_2.resources import (
+        MPICoresResReq,
+        MPINodesResReq,
+        ResourceRequirements,
+        ThreadedResReq,
+)
 from ymmsl.v0_2.settings import Settings, SettingValue
 from ymmsl.v0_2.supported_settings import (
-        SettingType, SupportedSetting, SupportedSettings)
-
+        SettingType,
+        SupportedSetting,
+        SupportedSettings,
+)
 
 __all__ = [
         'BaseEnv', 'CheckpointRule', 'CheckpointRangeRule', 'CheckpointAtRule',

--- a/ymmsl/v0_2/checkpoint.py
+++ b/ymmsl/v0_2/checkpoint.py
@@ -1,2 +1,6 @@
-from ymmsl.v0_1.checkpoint import (     # noqa: F401
-        CheckpointRule, CheckpointRangeRule, CheckpointAtRule, Checkpoints)
+from ymmsl.v0_1.checkpoint import (  # noqa: F401
+        CheckpointAtRule,
+        CheckpointRangeRule,
+        CheckpointRule,
+        Checkpoints,
+)

--- a/ymmsl/v0_2/component.py
+++ b/ymmsl/v0_2/component.py
@@ -56,9 +56,8 @@ class Component:
             self.implementation: Optional[Reference] = Reference(implementation)
             for part in self.implementation:
                 if isinstance(part, int):
-                    raise ValueError('Component implementation {} contains a'
-                                     ' subscript, which is not'
-                                     ' allowed.'.format(self.name))
+                    raise ValueError(f"Component implementation {self.name} contains a"
+                                     " subscript, which is not allowed.")
         else:
             self.implementation = None
 
@@ -73,12 +72,12 @@ class Component:
         """Returns a string representation of the object."""
         result = str(self.name)
         for dim in self.multiplicity:
-            result += '[0:{}]'.format(dim)
+            result += f"[0:{dim}]"
         return result
 
     def __repr__(self) -> str:
         """Returns a string representation of the object."""
-        return 'Component({})'.format(self.name)
+        return f"Component({self.name})"
 
     def instances(self) -> List[Reference]:
         """Creates a list of instances needed.

--- a/ymmsl/v0_2/component.py
+++ b/ymmsl/v0_2/component.py
@@ -1,11 +1,11 @@
-from typing import cast, List, Optional, Union
+from typing import List, Optional, Union, cast
 
 import yaml
 import yatiml
 
 from ymmsl.util import remove_trailing_whitespace
-from ymmsl.v0_2.ports import Ports
 from ymmsl.v0_2.identity import Reference
+from ymmsl.v0_2.ports import Ports
 
 
 class Component:

--- a/ymmsl/v0_2/configuration.py
+++ b/ymmsl/v0_2/configuration.py
@@ -1,28 +1,30 @@
 import collections.abc as abc
-from copy import copy
 import itertools
 import logging
+from copy import copy
 from pathlib import Path
-from typing import (
-        Dict, List, MutableMapping, Optional, Sequence, Tuple, Union, cast)
+from typing import Dict, List, MutableMapping, Optional, Sequence, Tuple, Union, cast
 
-import yatiml
 import yaml
+import yatiml
 
 from ymmsl.util import remove_trailing_whitespace
 from ymmsl.v0_2.checkpoint import Checkpoints
+from ymmsl.v0_2.document import Document
 from ymmsl.v0_2.execution import ExecutionModel
-from ymmsl.v0_2.resources import (
-    MPICoresResReq, MPINodesResReq, ResourceRequirements, ThreadedResReq)
 from ymmsl.v0_2.identity import Identifier, Reference
-from ymmsl.v0_2.implementation import Implementation    # noqa: F401
+from ymmsl.v0_2.implementation import Implementation  # noqa: F401
 from ymmsl.v0_2.imports import ImportStatement
+from ymmsl.v0_2.model import Component, Model
+from ymmsl.v0_2.program import Program
+from ymmsl.v0_2.resources import (
+    MPICoresResReq,
+    MPINodesResReq,
+    ResourceRequirements,
+    ThreadedResReq,
+)
 from ymmsl.v0_2.settings import Settings, SettingValue
 from ymmsl.v0_2.supported_settings import SettingType
-from ymmsl.v0_2.document import Document
-from ymmsl.v0_2.program import Program
-from ymmsl.v0_2.model import Component, Model
-
 
 _logger = logging.getLogger(__name__)
 

--- a/ymmsl/v0_2/document.py
+++ b/ymmsl/v0_2/document.py
@@ -1,5 +1,6 @@
 """Defines the YAML document and version tag."""
 import yatiml
+
 from ymmsl.document import Document as DocumentBase
 
 

--- a/ymmsl/v0_2/identity.py
+++ b/ymmsl/v0_2/identity.py
@@ -1,1 +1,1 @@
-from ymmsl.v0_1.identity import Identifier, Reference, ReferencePart    # noqa: F401
+from ymmsl.v0_1.identity import Identifier, Reference, ReferencePart  # noqa: F401

--- a/ymmsl/v0_2/implementation.py
+++ b/ymmsl/v0_2/implementation.py
@@ -1,4 +1,4 @@
-from typing import cast, Optional
+from typing import Optional, cast
 
 import yaml
 import yatiml

--- a/ymmsl/v0_2/imports.py
+++ b/ymmsl/v0_2/imports.py
@@ -63,8 +63,9 @@ class ImportStatement:
             self.kind = ImportKind[kind.upper()]
         except KeyError:
             raise ValueError(
-                    f'{kind} is not a valid kind of object to import. Try'
-                    ' "implementation" instead to import a program or a model.')
+                f'{kind} is not a valid kind of object to import. Try'
+                ' "implementation" instead to import a program or a model.'
+            ) from None
 
         self.name = Identifier(name)
 

--- a/ymmsl/v0_2/imports.py
+++ b/ymmsl/v0_2/imports.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pathlib import Path
-from typing import cast, Tuple
+from typing import Tuple, cast
 
 import yatiml
 

--- a/ymmsl/v0_2/model.py
+++ b/ymmsl/v0_2/model.py
@@ -115,7 +115,7 @@ class Conduit:
                     try:
                         self.filters.append(ConduitFilter(f))
                     except ValueError:
-                        raise RuntimeError(f'Invalid conduit filter "{f}"')
+                        raise RuntimeError(f'Invalid conduit filter "{f}"') from None
 
         self.__check_reference(self.sender)
         self.__check_reference(self.receiver)

--- a/ymmsl/v0_2/model.py
+++ b/ymmsl/v0_2/model.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from copy import copy
 from enum import Enum
-from typing import Any, cast, List, Optional, Sequence, Union
+from typing import Any, List, Optional, Sequence, Union, cast
 
 import yatiml
 

--- a/ymmsl/v0_2/ports.py
+++ b/ymmsl/v0_2/ports.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
-from typing import Any, cast, Iterator, List, Optional, overload, Sequence, Union
+from typing import Any, Iterator, List, Optional, Sequence, Union, cast, overload
 
-from ymmsl.v0_1.component import Operator   # also the v0.2 version, import from here
+from ymmsl.v0_1.component import Operator  # also the v0.2 version, import from here
 from ymmsl.v0_2.identity import Identifier, Reference
 
 

--- a/ymmsl/v0_2/ports.py
+++ b/ymmsl/v0_2/ports.py
@@ -270,8 +270,7 @@ class Ports:
 
     def __iter__(self) -> Iterator[Identifier]:
         """Iterate through the ports' names."""
-        for port_name in self._ports:
-            yield port_name
+        yield from self._ports
 
     def sending_port_names(self) -> List[Identifier]:
         """Return the names of all the sending ports.

--- a/ymmsl/v0_2/ports.py
+++ b/ymmsl/v0_2/ports.py
@@ -312,7 +312,7 @@ class Ports:
                 port_id = Identifier(name)
             except ValueError as e:
                 raise ValueError(
-                        f'Port name "{name}" is not a valid identifier. {e}')
+                        f'Port name "{name}" is not a valid identifier. {e}') from None
 
             self._ports[port_id] = Port(port_id, op, Timeline(timeline))
 

--- a/ymmsl/v0_2/program.py
+++ b/ymmsl/v0_2/program.py
@@ -1,6 +1,6 @@
 """Definitions for how to start programs."""
 from pathlib import Path
-from typing import cast, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union, cast
 
 import yaml
 import yatiml

--- a/ymmsl/v0_2/resolver.py
+++ b/ymmsl/v0_2/resolver.py
@@ -1,8 +1,8 @@
-from copy import copy
 import logging
 import os
 import sys
 from collections.abc import MutableMapping
+from copy import copy
 from difflib import get_close_matches
 from pathlib import Path
 from textwrap import indent

--- a/ymmsl/v0_2/resolver.py
+++ b/ymmsl/v0_2/resolver.py
@@ -573,6 +573,6 @@ def load_resolve_module(
         except RecognitionError as e:
             msg = ctx.trace()
             msg += indent(str(e), ' ' * 4)
-            raise RuntimeError(msg)
+            raise RuntimeError(msg) from None
 
     return ymmsl_cache[module_path]

--- a/ymmsl/v0_2/resources.py
+++ b/ymmsl/v0_2/resources.py
@@ -1,2 +1,6 @@
 from ymmsl.v0_1.execution import (  # noqa: F401
-        MPICoresResReq, MPINodesResReq, ResourceRequirements, ThreadedResReq,)
+        MPICoresResReq,
+        MPINodesResReq,
+        ResourceRequirements,
+        ThreadedResReq,
+)

--- a/ymmsl/v0_2/supported_settings.py
+++ b/ymmsl/v0_2/supported_settings.py
@@ -360,8 +360,7 @@ class SupportedSettings(MutableMapping):
 
     def __iter__(self) -> Iterator[Tuple[Identifier, SupportedSetting]]:
         """Iterate through the settings' key, supported_setting pairs."""
-        for key, value in self._store.items():
-            yield key, value
+        yield from self._store.items()
 
     def __len__(self) -> int:
         """Returns the number of settings."""

--- a/ymmsl/v0_2/supported_settings.py
+++ b/ymmsl/v0_2/supported_settings.py
@@ -213,10 +213,11 @@ class SupportedSetting:
                 try:
                     typ = SettingType(pieces[0])
                     description = pieces[1] if len(pieces) > 1 else ''
-                except KeyError:
+                except KeyError as exc:
                     raise ValueError(
-                            'If type is not given, then description must start with'
-                            f' the setting\'s type, which is not the case for "{name}"')
+                        'If type is not given, then description must start with'
+                        f' the setting\'s type, which is not the case for "{name}"'
+                    ) from exc
             # else typ is the type and description the description, so nothing to do
         else:
             # description is None, which is okay as long as we have a type

--- a/ymmsl/v0_2/tests/conftest.py
+++ b/ymmsl/v0_2/tests/conftest.py
@@ -3,11 +3,25 @@ from pathlib import Path
 import pytest
 
 from ymmsl.v0_2 import (
-        BaseEnv, Component, Conduit, Configuration, CheckpointRangeRule,
-        CheckpointAtRule, Checkpoints, KeepsStateForNextUse, ExecutionModel, Model,
-        MPICoresResReq, MPINodesResReq, Ports, Program, Reference, Settings,
-        SupportedSettings, ThreadedResReq)
-
+    BaseEnv,
+    CheckpointAtRule,
+    CheckpointRangeRule,
+    Checkpoints,
+    Component,
+    Conduit,
+    Configuration,
+    ExecutionModel,
+    KeepsStateForNextUse,
+    Model,
+    MPICoresResReq,
+    MPINodesResReq,
+    Ports,
+    Program,
+    Reference,
+    Settings,
+    SupportedSettings,
+    ThreadedResReq,
+)
 
 Ref = Reference
 

--- a/ymmsl/v0_2/tests/test_component.py
+++ b/ymmsl/v0_2/tests/test_component.py
@@ -1,6 +1,6 @@
-from ymmsl.v0_2 import Identifier, Component, Operator, Port, Ports, Reference, Timeline
-
 import pytest
+
+from ymmsl.v0_2 import Component, Identifier, Operator, Port, Ports, Reference, Timeline
 
 
 def test_component_declaration() -> None:

--- a/ymmsl/v0_2/tests/test_configuration.py
+++ b/ymmsl/v0_2/tests/test_configuration.py
@@ -3,12 +3,26 @@ from pathlib import Path
 
 import pytest
 
-from ymmsl.io import load, load_as, dump
+from ymmsl.io import dump, load, load_as
 from ymmsl.v0_2 import (
-        Configuration, Checkpoints, Component, Conduit, Identifier,
-        ImportStatement, Model, Operator, Port, Ports, Program, Reference, Settings,
-        SettingType, SettingValue, ThreadedResReq, Timeline)
-
+    Checkpoints,
+    Component,
+    Conduit,
+    Configuration,
+    Identifier,
+    ImportStatement,
+    Model,
+    Operator,
+    Port,
+    Ports,
+    Program,
+    Reference,
+    Settings,
+    SettingType,
+    SettingValue,
+    ThreadedResReq,
+    Timeline,
+)
 
 Ref = Reference
 

--- a/ymmsl/v0_2/tests/test_imports.py
+++ b/ymmsl/v0_2/tests/test_imports.py
@@ -1,12 +1,11 @@
 from pathlib import Path
-from typing import Any, AnyStr, Callable, IO, Union
-import yatiml
+from typing import IO, Any, AnyStr, Callable, Union
 
 import pytest
+import yatiml
 
 from ymmsl.v0_2.identity import Identifier, Reference
 from ymmsl.v0_2.imports import ImportKind, ImportStatement
-
 
 LoadImport = Callable[[Union[str, Path, IO[AnyStr]]], Any]
 

--- a/ymmsl/v0_2/tests/test_model.py
+++ b/ymmsl/v0_2/tests/test_model.py
@@ -1,14 +1,16 @@
+import pytest
+import yatiml
+
 from ymmsl.v0_2.component import Component
 from ymmsl.v0_2.identity import Identifier
 from ymmsl.v0_2.implementation import Implementation, Reference
 from ymmsl.v0_2.model import Conduit, ConduitFilter, Model, MulticastConduit
 from ymmsl.v0_2.ports import Operator, Port, Ports, Timeline
 from ymmsl.v0_2.supported_settings import (
-        SettingType, SupportedSetting, SupportedSettings)
-
-import pytest
-import yatiml
-
+    SettingType,
+    SupportedSetting,
+    SupportedSettings,
+)
 
 Ref = Reference
 

--- a/ymmsl/v0_2/tests/test_ports.py
+++ b/ymmsl/v0_2/tests/test_ports.py
@@ -1,9 +1,8 @@
-from ymmsl.v0_2.identity import Identifier, Reference
-from ymmsl.v0_2.ports import Operator, Port, Ports, Timeline
-
 import pytest
 import yatiml
 
+from ymmsl.v0_2.identity import Identifier, Reference
+from ymmsl.v0_2.ports import Operator, Port, Ports, Timeline
 
 Ref = Reference
 

--- a/ymmsl/v0_2/tests/test_program.py
+++ b/ymmsl/v0_2/tests/test_program.py
@@ -3,13 +3,16 @@ from pathlib import Path
 import pytest
 import yatiml
 
-from ymmsl.v0_2.ports import Operator, Ports
 from ymmsl.v0_2.execution import BaseEnv, ExecutionModel, KeepsStateForNextUse
 from ymmsl.v0_2.identity import Identifier, Reference
 from ymmsl.v0_2.implementation import Implementation
+from ymmsl.v0_2.ports import Operator, Ports
 from ymmsl.v0_2.program import Program
 from ymmsl.v0_2.supported_settings import (
-        SettingType, SupportedSetting, SupportedSettings)
+    SettingType,
+    SupportedSetting,
+    SupportedSettings,
+)
 
 
 def test_program_script_list() -> None:

--- a/ymmsl/v0_2/tests/test_resolver.py
+++ b/ymmsl/v0_2/tests/test_resolver.py
@@ -1,9 +1,9 @@
 import logging
+import os
 import sys
 from collections.abc import Generator
-import os
 from pathlib import Path
-from unittest.mock import patch, Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -13,9 +13,9 @@ from ymmsl.v0_2.identity import Reference
 from ymmsl.v0_2.resolver import resolve
 
 if sys.version_info < (3, 10):
-    from importlib_metadata import EntryPoints, EntryPoint
+    from importlib_metadata import EntryPoint, EntryPoints
 else:
-    from importlib.metadata import EntryPoints, EntryPoint
+    from importlib.metadata import EntryPoint, EntryPoints
 
 Ref = Reference
 

--- a/ymmsl/v0_2/tests/test_supported_settings.py
+++ b/ymmsl/v0_2/tests/test_supported_settings.py
@@ -1,8 +1,7 @@
-from ymmsl.v0_2 import (
-        Identifier, SettingType, SupportedSetting, SupportedSettings)
-
 import pytest
 import yatiml
+
+from ymmsl.v0_2 import Identifier, SettingType, SupportedSetting, SupportedSettings
 
 
 @pytest.fixture


### PR DESCRIPTION
Enable additional ruff linting rules

Most changes are trivial, but please check if you agree with my solution for the base `ymmsl.document.Document` class:
- Rules triggered by ruff:
  1. B024 `Document` is an abstract base class, but it has no abstract methods or properties
  2. B027 `Document.__init__` is an empty method in an abstract base class, but has no abstract decorator
- I tried making `__init__` an abstract method (and add a concrete `__init__` method to `ymmsl.v0_1.document.Document`) but then `mypy` complains: *ymmsl/io.py:34: error: Only concrete class can be given where "type[Document]" is expected  [type-abstract]*
  So instead I completely removed the ABC superclass from `document.Document`.

Suggested to review commit-by-commit and don't spend too much time at the import sorting commit 🙂 